### PR TITLE
A fix for drawing the minimap with unequal width and height values

### DIFF
--- a/CommandLineFPS.cpp
+++ b/CommandLineFPS.cpp
@@ -268,7 +268,7 @@ int main()
 
 		// Display Map
 		for (int nx = 0; nx < nMapWidth; nx++)
-			for (int ny = 0; ny < nMapWidth; ny++)
+			for (int ny = 0; ny < nMapHeightWidth; ny++)
 			{
 				screen[(ny+1)*nScreenWidth + nx] = map[ny * nMapWidth + nx];
 			}

--- a/CommandLineFPS.cpp
+++ b/CommandLineFPS.cpp
@@ -268,7 +268,7 @@ int main()
 
 		// Display Map
 		for (int nx = 0; nx < nMapWidth; nx++)
-			for (int ny = 0; ny < nMapHeightWidth; ny++)
+			for (int ny = 0; ny < nMapHeight; ny++)
 			{
 				screen[(ny+1)*nScreenWidth + nx] = map[ny * nMapWidth + nx];
 			}


### PR DESCRIPTION
To resolve issue 9 (https://github.com/OneLoneCoder/CommandLineFPS/issues/9).