### PR TITLE
Opened the std namespace after windows.h

### DIFF
--- a/CommandLineFPS.cpp
+++ b/CommandLineFPS.cpp
@@ -70,10 +70,9 @@
 #include <utility>
 #include <algorithm>
 #include <chrono>
-using namespace std;
-
 #include <stdio.h>
 #include <Windows.h>
+using namespace std;
 
 int nScreenWidth = 120;			// Console Screen Size X (columns)
 int nScreenHeight = 40;			// Console Screen Size Y (rows)


### PR DESCRIPTION
I ran into an issue in the latest Visual Studio (16.8.4) where rpcndr.h was giving error C2872: 'byte': ambiguous symbol. The fix was relatively simple as all that was needed was to open the std namepsace after windows.h.

As given here : https://developercommunity.visualstudio.com/content/problem/93889/error-c2872-byte-ambiguous-symbol.html